### PR TITLE
build: add vscode debug setting

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [{
+    // You need the "Debugger for Chrome" VSCode Extension
+    "name": "Launch Chrome to debug shaderity graph samples",
+    "request": "launch",
+    "type": "chrome",
+    "webRoot": "${workspaceFolder}",
+    "url": "http://localhost:8082/samples/simple",
+    "skipFiles": [
+      "<node_internals>/**"
+    ],
+    // "preLaunchTask": "npm: build-umd-dev",
+    // "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+    "sourceMaps": true,
+    "smartStep": true,
+    "internalConsoleOptions": "openOnSessionStart",
+  }]
+}


### PR DESCRIPTION
This PR will allow you to use the debug mode of VS code. Use it in combination with `yarn watch-samples`.