### PR TITLE
build: update shaderity

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
-    "shaderity": "^0.1.28"
+    "shaderity": ".\\shaderity-v0.2.0.tgz"
   },
   "scripts": {
     "prepare": "husky install",


### PR DESCRIPTION
This PR supports #26.

Currently, the published version of the shaderity is too old(v0.1.x). We need to publish a new version of the shaderity before merge this PR
