### PR TITLE
feat: allow array type uniform variable

### DIFF
--- a/src/shaderGraph/ShaderGraphResolver.ts
+++ b/src/shaderGraph/ShaderGraphResolver.ts
@@ -539,7 +539,7 @@ ${functionCalls}
     let returnStr = `  ${node.functionName}(`;
 
     for (let i = 0; i < argumentNames.length; i++) {
-      const argumentName = argumentNames[i];
+      const argumentName = argumentNames[i].split('[')[0];
       returnStr += argumentName + ', ';
     }
 


### PR DESCRIPTION
This PR modifies the variable name when calling an array type uniform variable.

Currently, the variableName property of the uniform input socket is used in the declaration and invocation of uniform variables. In the case of an array-type uniform variable, the variableName property is, for example, as follows
````
u_variable[4]
````
This '[4]' is the number of elements in the array when declaring the variable, and the index of the array when calling it. This difference in interpretation causes a compile error. This PR fixes it.